### PR TITLE
Add Docker setup for always-on deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM oven/bun:1-slim
+
+WORKDIR /app
+
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production
+
+COPY src ./src
+
+CMD ["bun", "run", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  simpleclaw:
+    build: .
+    restart: unless-stopped
+    # If the app exposes any ports, you can uncomment and map them here
+    # ports:
+    #   - "3000:3000"
+    environment:
+      - NODE_ENV=production


### PR DESCRIPTION
Adds Docker setup to the repository so the app can be easily run in a self-recovering container using `docker-compose`.

---
*PR created automatically by Jules for task [9439819279970037363](https://jules.google.com/task/9439819279970037363) started by @stancsz*