### PR TITLE
fix: Robust Git refs for CI

### DIFF
--- a/.github/scripts/reviewer.ts
+++ b/.github/scripts/reviewer.ts
@@ -47,7 +47,7 @@ async function main() {
         const specMd = execSync("git show origin/development:SPEC.md", { encoding: "utf-8" });
         
         // Get diff against development
-        const diff = execSync("git diff origin/development...HEAD", { encoding: "utf-8" });
+        const diff = execSync("git diff origin/origin/development...HEAD", { encoding: "utf-8" });
 
         const systemPrompt = `You are the "Principal Integrity Officer" for SimpleClaw.
 Your job is to review Pull Requests and decide whether to MERGE or CLOSE them.


### PR DESCRIPTION
Ensures the reviewer can always find the development branch for diffing in the GitHub Actions environment.