### PR TITLE
fix: prevent LINT-FIX LOOP from triggering on ESLint warnings

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -1145,9 +1145,16 @@ ONLY EVER RETURN CODE IN A SEARCH/REPLACE BLOCK!
    * Covers: compile errors, runtime errors, lint errors, test failures.
    */
   private detectRunFailure(output: string): boolean {
+    // Only match actual build/test failures — not ESLint warnings
+    // Real errors appear at line start: "✗", "error:", "Error:", "FAILED", "Build failed"
+    // Warnings don't have these prefixes
     const failurePatterns = [
-      /\b(error|Error|ERROR|failed|FAILED|Failed)\b/,
-      /\b(fatal|FATAL)\b/,
+      /^Error:/m,                    // Error at start of line (not "warning" context)
+      /^error:/m,                    // lowercase error at line start
+      /^✗/m,                         // failure X symbol
+      /^FAILED$/m,                   // all-caps FAILED
+      /\bfailed\b/i,                 // "failed" case-insensitive
+      /\bfatal\b/i,                  // fatal error
       /\bSyntaxError\b/,
       /\bReferenceError\b/,
       /\bTypeError\b/,


### PR DESCRIPTION
## Summary

Fix the LINT-FIX LOOP in `src/agent/agent.ts` — it was incorrectly triggering on ESLint warnings (not just errors), causing a false-positive recovery loop on every `meow -p` run.

**Root cause:** `detectRunFailure()` used `/\b(error|Error|ERROR|failed|FAILED|Failed)\b/` which matches "error" anywhere in the output, including in "warning" lines from ESLint.

**Fix:** Changed `detectRunFailure()` to use line-anchor patterns (`^Error:`, `^✗`, etc.) that only fire on actual failure indicators at the start of a line, not the word "error" appearing anywhere.

## Test plan

- [x] `bun run lint` exits 0 — no new lint errors introduced
- [x] Verified fix works by running `meow -p "echo test"` — no false LINT-FIX LOOP trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)