### PR TITLE
fix: increase fixMeow timeout to 300s and close stdin to prevent hang

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -361,8 +361,10 @@ DO NOT attempt to complete the original task. Only fix MEOW's machinery.
 
         const timer = setTimeout(() => {
           child.kill();
-          resolve(`❌ claude -p timed out after 180s\nSTDERR: ${stderr.substring(0, 500)}`);
-        }, 180_000);
+          resolve(`❌ claude -p timed out after 300s\nSTDERR: ${stderr.substring(0, 500)}`);
+        }, 300_000);
+
+        child.stdin?.end();
 
         child.on("close", (code: number | null) => {
           clearTimeout(timer);


### PR DESCRIPTION
## Summary

- Increase `fixMeow()` timeout from 180s to 300s — fixes false timeout when `claude -p` takes longer to produce output
- Close `child.stdin` after spawning — prevents the "no stdin data received in 3s" warning that causes `claude -p` to proceed without input on Windows

## Test plan

- [x] `bun run typecheck && bun run lint` passes (0 errors, only warnings)
- [ ] Verify `fixMeow()` completes successfully on a test failure scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)