### PR TITLE
feat: track skills in .claude/ and add --target flag

### DIFF
--- a/.claude/skills/meow/SKILL.md
+++ b/.claude/skills/meow/SKILL.md
@@ -34,17 +34,23 @@ bun bin/meow.ts -p "fix the auth bug in src/auth.ts"
 bun bin/meow.ts status
 ```
 
+## Run the loop (9 lives default)
+
+```bash
+bun bin/meow.ts live
+```
+
+## Run N lives
+
+```bash
+bun bin/meow.ts live --lives 3
+```
+
 ## Run against a target repo (default: ~/github/meow)
 
 ```bash
 bun bin/meow.ts --target ~/github/flint status
 node driver.mjs --target ~/github/flint status
-```
-
-## Run the loop (9 lives default)
-
-```bash
-bun bin/meow.ts live
 ```
 
 ## Prerequisites

--- a/.claude/skills/meow/driver.mjs
+++ b/.claude/skills/meow/driver.mjs
@@ -2,7 +2,7 @@
 /**
  * meow driver — wraps bin/meow.ts for programmatic use.
  * Usage: node driver.mjs <command> [opts]
- * 
+ *
  * Commands: status, -p <task>, live [--lives N], review, birth, mock
  * Options:
  *   --target <path>   operate on a different repo's .meow/ (default: ~/github/meow)


### PR DESCRIPTION
## Summary
- Track skills in `.claude/` for portable clone+install
- Add `--target` flag to operate on a different repo's `.meow/`

## Test plan
- [ ] Clone fresh → skills appear in .claude/
- [ ] `bun bin/meow.ts --target ~/github/flint status` works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)